### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/activity_wallet_gen.xml
+++ b/app/src/main/res/layout/activity_wallet_gen.xml
@@ -72,6 +72,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/prompt_email"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:maxLines="1"
                     android:singleLine="true" />
 
@@ -87,6 +88,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/prompt_password"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:maxLines="1"
                     android:singleLine="true" />
 


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.